### PR TITLE
fix: fix reload command

### DIFF
--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -353,6 +353,17 @@ def target_func(x, y):
     return x + y
 ```
 
+4. **Function Parameter Redefinition Limitations**: When constructing a new function, the default values of function parameters will be stored in the function's `__defaults__` variable. Therefore, if the default values of function parameters contain calls to other functions, implicit function calls will be triggered. Refer to the following example:
+
+```python
+def get_default_time():
+    return "2026-02-01"
+
+def my_func(time_str=get_default_time()):
+    # When my_func is modified in place, `get_default_time` function will be called in the new function creation
+    print(time_str)
+```
+
 #### Output Display
 Usage examples:
 

--- a/docs/WIKI_zh.md
+++ b/docs/WIKI_zh.md
@@ -356,6 +356,17 @@ def target_func(x, y):
     return x + y
 ```
 
+4. **函数入参重定义限制**: 在构建新函数时，会将函数的入参默认值存储至函数的__defaults__ 变量中，因此若有函数入参默认值中含有其他函数调用的情况，则会触发隐式函数调用，参考如下示例。
+
+```python
+def get_default_time():
+    return "2026-02-01"
+
+def my_func(time_str=get_default_time()):
+    # When my_func is modified in place, `get_default_time` function will be called in the new function creation
+    print(time_str)
+```
+
 #### 输出展示
 使用示例如下：
 


### PR DESCRIPTION
1. use original module's global space to avoid load_name bytecode missing definition.
2. use empty class statements wrapper to avoid class initialization re-execute.
3. add doc limitation for method